### PR TITLE
Update pipelines for builders without pem onboard

### DIFF
--- a/gnbsim.groovy
+++ b/gnbsim.groovy
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// gnbsim.groovy
 
 pipeline {
   options {
@@ -9,9 +10,13 @@ pipeline {
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+  }
+
   stages{
-      
+
     stage('Verify AWS Accessible') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
@@ -29,44 +34,46 @@ pipeline {
           }
         }
     }
-    
+
     stage('Configure OnRamp') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            sh """
-              NEWIP=\$(aws --region us-west-2 ec2 describe-instances \
-                           --instance-ids i-000f1f7e33fe5a86e \
-                           --query 'Reservations[0].Instances[0].PrivateIpAddress')
-              echo \$NEWIP
-              WORKERIP=\$(echo \$NEWIP | tr -d '"')
-              echo \$WORKERIP
-              cd $WORKSPACE
-              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-              cd aether-onramp
-              # Determine Local IP
-              MYIP=\$(hostname -I | awk '{print \$1}')
-              echo "MY IP is: " \$MYIP
-              which curl
-              which wget
-              MYID=\$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
-              echo "MYID is " \$MYID
-              aws --region us-west-2 ec2 modify-instance-attribute --no-source-dest-check \
-                  --instance-id \$MYID
-              echo "WORKER SourceDestCheck"
-              aws --region us-west-2 ec2 describe-instances --instance-ids i-000f1f7e33fe5a86e \
-                  --query 'Reservations[0].Instances[0].NetworkInterfaces[0].SourceDestCheck'
-              echo "MAIN SourceDestCheck"
-              aws --region us-west-2 ec2 describe-instances --instance-ids \$MYID \
-                  --query 'Reservations[0].Instances[0].NetworkInterfaces[0].SourceDestCheck'
-              # Determine active network interface (8.8.8.8 is Google)
-              MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-              echo "MY IFC is: " \$MYIFC
-              # Create appropriate hosts.ini file
-              cat > hosts.ini << EOF
+          credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+          sshUserPrivateKey(credentialsId: 'aether-qa', keyFileVariable: 'aether_qa')]) {
+        sh '''
+          NEWIP=\$(aws --region us-west-2 ec2 describe-instances \
+                       --instance-ids i-000f1f7e33fe5a86e \
+                       --query 'Reservations[0].Instances[0].PrivateIpAddress')
+          echo \$NEWIP
+          WORKERIP=\$(echo \$NEWIP | tr -d '"')
+          echo \$WORKERIP
+          cp -p "$aether_qa" "$PEM_PATH"
+          cd $WORKSPACE
+          git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+          cd aether-onramp
+          # Determine Local IP
+          MYIP=\$(hostname -I | awk '{print \$1}')
+          echo "MY IP is: " \$MYIP
+          which curl
+          which wget
+          MYID=\$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
+          echo "MYID is " \$MYID
+          aws --region us-west-2 ec2 modify-instance-attribute --no-source-dest-check \
+              --instance-id \$MYID
+          echo "WORKER SourceDestCheck"
+          aws --region us-west-2 ec2 describe-instances --instance-ids i-000f1f7e33fe5a86e \
+              --query 'Reservations[0].Instances[0].NetworkInterfaces[0].SourceDestCheck'
+          echo "MAIN SourceDestCheck"
+          aws --region us-west-2 ec2 describe-instances --instance-ids \$MYID \
+              --query 'Reservations[0].Instances[0].NetworkInterfaces[0].SourceDestCheck'
+          # Determine active network interface (8.8.8.8 is Google)
+          MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+          echo "MY IFC is: " \$MYIFC
+          # Create appropriate hosts.ini file
+          cat > hosts.ini << EOF
 [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
-node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
+node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -85,7 +92,7 @@ EOF
               grep -rl "ens18" . | xargs sed -i "s/ens18/\$MYIFC/g"
               sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
               make aether-pingall
-            """ 
+            '''
           }
         }
     }
@@ -98,85 +105,88 @@ EOF
             make aether-5gc-install
             make aether-gnbsim-install
             kubectl get pods -n aether-5gc
-          """ 
+          """
         }
     }
-    
+
     stage("Run gNBsim"){
         steps {
-            sh """
-              cd $WORKSPACE/aether-onramp
-              NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
-              sleep 60
-              make aether-gnbsim-run
-              cd /home/ubuntu
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                 "docker exec  gnbsim-1 cat summary.log"
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                 "docker exec  gnbsim-2 cat summary.log"
-            """
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+                sh """
+                  cd $WORKSPACE/aether-onramp
+                  NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
+                  sleep 60
+                  make aether-gnbsim-run
+                  cd /home/ubuntu
+                  ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                     "docker exec  gnbsim-1 cat summary.log"
+                  ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                     "docker exec  gnbsim-2 cat summary.log"
+                """
+            }
         }
     }
-    
+
     stage("Validate Results"){
         steps {
           catchError(message:'Gnbsim Validation is failed', buildResult:'FAILURE',
-            stageResult:'FAILURE') {
+          stageResult:'FAILURE') {
               sh """
                 cd $WORKSPACE/aether-onramp
                 NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
                 cd /home/ubuntu
                 # weaker validation test
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                     "docker exec gnbsim-1 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                     "docker exec gnbsim-2 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
               """
           }
         }
     }
-    
+
     stage("Retrieve Logs") {
         steps {
-            sh """
-              mkdir $WORKSPACE/logs
-              cd $WORKSPACE/aether-onramp
-              NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
-              cd /home/ubuntu
-              LOGFILE=\$(ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker exec  gnbsim-1 ls " | grep "gnbsim1-.*.log")  || true
-              echo \$LOGFILE
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker cp gnbsim-1:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
-              scp -i "aether-qa.pem" -o StrictHostKeyChecking=no \
-                     ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
-              LOGFILE=\$(ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker exec  gnbsim-2 ls " | grep "gnbsim2-.*.log")  || true
-              echo \$LOGFILE
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker cp gnbsim-2:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
-              scp -i "aether-qa.pem" -o StrictHostKeyChecking=no \
-                     ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
-              cd $WORKSPACE/logs
-              AMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep amf | awk 'NR==1{print \$1}')
-              echo \$AMF_POD_NAME
-              kubectl logs \$AMF_POD_NAME -n aether-5gc > gnbsim_amf.log
-              WEBUI_POD_NAME=\$(kubectl get pods -n aether-5gc | grep webui | awk 'NR==1{print \$1}')
-              echo \$WEBUI_POD_NAME
-              kubectl logs \$WEBUI_POD_NAME -n aether-5gc > gnbsim_webui.log
-              UDR_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udr | awk 'NR==1{print \$1}')
-              echo \$UDR_POD_NAME
-              kubectl logs \$UDR_POD_NAME -n aether-5gc > gnbsim_udr.log
-              UDM_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udm | awk 'NR==1{print \$1}')
-              echo \$UDM_POD_NAME
-              kubectl logs \$UDM_POD_NAME -n aether-5gc > gnbsim_udm.log
-              AUSF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep ausf | awk 'NR==1{print \$1}')
-              echo \$AUSF_POD_NAME
-              kubectl logs \$AUSF_POD_NAME -n aether-5gc > gnbsim_ausf.log
-              SMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep smf | awk 'NR==1{print \$1}')
-              echo \$SMF_POD_NAME
-              kubectl logs \$SMF_POD_NAME -n aether-5gc > gnbsim_smf.log
-            """
+          sh """
+            mkdir $WORKSPACE/logs
+            cd $WORKSPACE/aether-onramp
+            NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
+            cd /home/ubuntu
+            LOGFILE=\$(ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker exec  gnbsim-1 ls " | grep "gnbsim1-.*.log")  || true
+            echo \$LOGFILE
+            ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker cp gnbsim-1:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
+            scp -i "$PEM_PATH" -o StrictHostKeyChecking=no \
+                   ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
+            LOGFILE=\$(ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker exec  gnbsim-2 ls " | grep "gnbsim2-.*.log")  || true
+            echo \$LOGFILE
+            ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker cp gnbsim-2:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
+            scp -i "$PEM_PATH" -o StrictHostKeyChecking=no \
+                   ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
+            cd $WORKSPACE/logs
+            AMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep amf | awk 'NR==1{print \$1}')
+            echo \$AMF_POD_NAME
+            kubectl logs \$AMF_POD_NAME -n aether-5gc > gnbsim_amf.log
+            WEBUI_POD_NAME=\$(kubectl get pods -n aether-5gc | grep webui | awk 'NR==1{print \$1}')
+            echo \$WEBUI_POD_NAME
+            kubectl logs \$WEBUI_POD_NAME -n aether-5gc > gnbsim_webui.log
+            UDR_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udr | awk 'NR==1{print \$1}')
+            echo \$UDR_POD_NAME
+            kubectl logs \$UDR_POD_NAME -n aether-5gc > gnbsim_udr.log
+            UDM_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udm | awk 'NR==1{print \$1}')
+            echo \$UDM_POD_NAME
+            kubectl logs \$UDM_POD_NAME -n aether-5gc > gnbsim_udm.log
+            AUSF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep ausf | awk 'NR==1{print \$1}')
+            echo \$AUSF_POD_NAME
+            kubectl logs \$AUSF_POD_NAME -n aether-5gc > gnbsim_ausf.log
+            SMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep smf | awk 'NR==1{print \$1}')
+            echo \$SMF_POD_NAME
+            kubectl logs \$SMF_POD_NAME -n aether-5gc > gnbsim_smf.log
+          """
         }
     }
 
@@ -201,11 +211,11 @@ EOF
         """
       }
     }
-    
+
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
+
     }
   }
 }

--- a/quickstart.groovy
+++ b/quickstart.groovy
@@ -1,30 +1,37 @@
 // SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// quickstart.groovy
 
 pipeline {
   options {
-    timeout(time: 1, unit: 'HOURS') 
+    timeout(time: 1, unit: 'HOURS')
   }
 
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+  }
+
   stages{
 
     stage('Configure OnRamp') {
         steps {
-          sh """
-            cd $WORKSPACE
-            git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-            cd aether-onramp
-            MYIP=\$(hostname -I | awk '{print \$1}')
-            echo "MY IP is: " \$MYIP
-            MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-            echo "MY IFC is: " \$MYIFC
-            cat > hosts.ini << EOF
-            [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+              sh '''
+                cp -p "$aether_qa" "$PEM_PATH"
+                git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+                cd aether-onramp
+                MYIP=\$(hostname -I | awk '{print \$1}')
+                echo "MY IP is: " \$MYIP
+                MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+                echo "MY IFC is: " \$MYIFC
+                cat > hosts.ini << EOF
+                [all]
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -35,14 +42,15 @@ node1
 [gnbsim_nodes]
 node1
 EOF
-            sudo cp vars/main-quickstart.yml vars/main.yml
-            sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
-            sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
-            make aether-pingall
-          """ 
+                sudo cp vars/main-quickstart.yml vars/main.yml
+                sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
+                sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
+                make aether-pingall
+              '''
+            }
         }
     }
-    
+
     stage('Install Aether') {
         steps {
           sh """
@@ -52,7 +60,7 @@ EOF
             make aether-gnbsim-install
             kubectl get pods -n aether-5gc
             docker ps
-          """ 
+          """
         }
     }
 
@@ -65,7 +73,7 @@ EOF
                    make aether-gnbsim-run
                    docker exec gnbsim-1 cat summary.log
                  """
-            } 
+            }
         }
     }
 
@@ -77,10 +85,10 @@ EOF
                   # weaker validation test
                   docker exec gnbsim-1 cat summary.log | grep "Ue's Passed" | grep -v "Passed: 0"
                 """
-            }    
+            }
         }
     }
-	
+
     stage ('Retrieve Logs'){
         steps {
             sh '''
@@ -132,7 +140,7 @@ EOF
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
+
     }
   }
 }

--- a/quickstart_amp.groovy
+++ b/quickstart_amp.groovy
@@ -1,30 +1,37 @@
 // SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// quickstart_amp.groovy
 
 pipeline {
   options {
-    timeout(time: 1, unit: 'HOURS') 
+    timeout(time: 1, unit: 'HOURS')
   }
 
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+  }
+
   stages{
 
     stage('Configure OnRamp') {
         steps {
-          sh """
-            cd $WORKSPACE
-            git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-            cd aether-onramp
-            MYIP=\$(hostname -I | awk '{print \$1}')
-            echo "MY IP is: " \$MYIP
-            MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-            echo "MY IFC is: " \$MYIFC
-            cat > hosts.ini << EOF
-            [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+              sh '''
+                cp -p "$aether_qa" "$PEM_PATH"
+                git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+                cd aether-onramp
+                MYIP=\$(hostname -I | awk '{print \$1}')
+                echo "MY IP is: " \$MYIP
+                MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+                echo "MY IFC is: " \$MYIFC
+                cat > hosts.ini << EOF
+                [all]
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -35,15 +42,16 @@ node1
 [gnbsim_nodes]
 node1
 EOF
-            sudo cp vars/main-quickstart.yml vars/main.yml
-            sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
-            sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
-            sudo sed -i "s/standalone: true/standalone: false/" vars/main.yml
-            make aether-pingall
-          """ 
+                sudo cp vars/main-quickstart.yml vars/main.yml
+                sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
+                sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
+                sudo sed -i "s/standalone: true/standalone: false/" vars/main.yml
+                make aether-pingall
+              '''
+            }
         }
     }
-    
+
     stage('Install Aether') {
         steps {
           sh """
@@ -54,7 +62,7 @@ EOF
             make aether-gnbsim-install
             kubectl get pods -n aether-5gc
             docker ps
-          """ 
+          """
         }
     }
 
@@ -67,7 +75,7 @@ EOF
                    make aether-gnbsim-run
                    docker exec gnbsim-1 cat summary.log
                  """
-            } 
+            }
         }
     }
 
@@ -79,10 +87,10 @@ EOF
                   # weaker validation test
                   docker exec gnbsim-1 cat summary.log | grep "Ue's Passed" | grep -v "Passed: 0"
                 """
-            }    
+            }
         }
     }
-	
+
     stage ('Retrieve Logs'){
         steps {
             sh '''
@@ -135,7 +143,7 @@ EOF
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
+
     }
   }
 }

--- a/upf-alt.groovy
+++ b/upf-alt.groovy
@@ -1,30 +1,37 @@
 // SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// upf-alt.groovy
 
 pipeline {
   options {
-    timeout(time: 1, unit: 'HOURS') 
+    timeout(time: 1, unit: 'HOURS')
   }
 
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+  }
+
   stages{
 
     stage('Configure OnRamp') {
         steps {
-          sh """
-            cd $WORKSPACE
-            git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-            cd aether-onramp
-            MYIP=\$(hostname -I | awk '{print \$1}')
-            echo "MY IP is: " \$MYIP
-            MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-            echo "MY IFC is: " \$MYIFC
-            cat > hosts.ini << EOF
-            [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+              sh '''
+                cp -p "$aether_qa" "$PEM_PATH"
+                git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+                cd aether-onramp
+                MYIP=\$(hostname -I | awk '{print \$1}')
+                echo "MY IP is: " \$MYIP
+                MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+                echo "MY IFC is: " \$MYIFC
+                cat > hosts.ini << EOF
+                [all]
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -35,15 +42,16 @@ node1
 [gnbsim_nodes]
 node1
 EOF
-            sudo cp vars/main-upf.yml vars/main.yml
-            sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
-            sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
-            sudo sed -i "s/standalone: true/standalone: false/" vars/main.yml
-            make aether-pingall
-          """ 
+                sudo cp vars/main-upf.yml vars/main.yml
+                sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
+                sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
+                sudo sed -i "s/standalone: true/standalone: false/" vars/main.yml
+                make aether-pingall
+              """
+            }
         }
     }
-    
+
     stage('Install Aether') {
         steps {
           sh """
@@ -58,7 +66,7 @@ EOF
             make gnbsim-install
             kubectl get pods --all-namespaces
             docker ps
-          """ 
+          '''
         }
     }
 
@@ -72,7 +80,7 @@ EOF
                    docker exec gnbsim-1 cat summary.log
                    docker exec gnbsim-2 cat summary.log
                  """
-            } 
+            }
         }
     }
 
@@ -84,10 +92,10 @@ EOF
                   docker exec gnbsim-1 cat summary.log  | grep "Profile Status: PASS"
                   docker exec gnbsim-2 cat summary.log  | grep "Profile Status: PASS"
                 """
-            }    
+            }
         }
     }
-	
+
     stage ('Retrieve Logs'){
         steps {
             sh '''
@@ -143,7 +151,7 @@ EOF
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
+
     }
   }
 }

--- a/upf.groovy
+++ b/upf.groovy
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// upf.groovy
 
 pipeline {
   options {
@@ -9,9 +10,13 @@ pipeline {
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+  }
+
   stages{
-      
+
     stage('Verify AWS Accessible') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
@@ -29,20 +34,22 @@ pipeline {
           }
         }
     }
-    
+
     stage('Configure OnRamp') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            sh """
+              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+              sshUserPrivateKey(credentialsId: 'aether-qa', keyFileVariable: 'aether_qa')]) {
+            sh '''
               NEWIP=\$(aws --region us-west-2 ec2 describe-instances \
                            --instance-ids i-000f1f7e33fe5a86e \
                            --query 'Reservations[0].Instances[0].PrivateIpAddress')
               echo \$NEWIP
               WORKERIP=\$(echo \$NEWIP | tr -d '"')
               echo \$WORKERIP
+              cp -p "$aether_qa" "$PEM_PATH"
               cd $WORKSPACE
-              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
+              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
               cd aether-onramp
               # Determine Local IP
               MYIP=\$(hostname -I | awk '{print \$1}')
@@ -65,8 +72,8 @@ pipeline {
               # Create appropriate hosts.ini file
               cat > hosts.ini << EOF
 [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
-node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
+node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -85,7 +92,7 @@ EOF
               sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
               sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
               make aether-pingall
-            """ 
+            '''
           }
         }
     }
@@ -104,10 +111,10 @@ EOF
             make roc-load
             make gnbsim-install
             kubectl get pods --all-namespaces
-          """ 
+          """
         }
     }
-    
+
     stage("Run gNBsim"){
         steps {
             sh """
@@ -117,14 +124,14 @@ EOF
               kubectl get pods -n aether-5gc
               make aether-gnbsim-run
               cd /home/ubuntu
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+              ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                  "docker exec  gnbsim-1 cat summary.log"
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+              ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                  "docker exec  gnbsim-2 cat summary.log"
             """
         }
     }
-    
+
     stage("Validate Results"){
         steps {
           catchError(message:'Gnbsim Validation is failed', buildResult:'FAILURE',
@@ -134,15 +141,15 @@ EOF
                 NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
                 cd /home/ubuntu
                 # weaker validation test
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                     "docker exec gnbsim-1 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                     "docker exec gnbsim-2 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
               """
           }
         }
     }
-    
+
     stage("Retrieve Logs") {
         steps {
             sh """
@@ -150,19 +157,19 @@ EOF
               cd $WORKSPACE/aether-onramp
               NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
               cd /home/ubuntu
-              LOGFILE=\$(ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+              LOGFILE=\$(ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                      "docker exec  gnbsim-1 ls " | grep "gnbsim1-.*.log")  || true
               echo \$LOGFILE
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+              ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                      "docker cp gnbsim-1:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
-              scp -i "aether-qa.pem" -o StrictHostKeyChecking=no \
+              scp -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no \
                      ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
-              LOGFILE=\$(ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+              LOGFILE=\$(ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                      "docker exec  gnbsim-2 ls " | grep "gnbsim2-.*.log")  || true
               echo \$LOGFILE
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+              ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
                      "docker cp gnbsim-2:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
-              scp -i "aether-qa.pem" -o StrictHostKeyChecking=no \
+              scp -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no \
                      ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
               cd $WORKSPACE/logs
               AMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep amf | awk 'NR==1{print \$1}')
@@ -208,11 +215,11 @@ EOF
         """
       }
     }
-    
+
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
+
     }
   }
 }


### PR DESCRIPTION
While updating our build images for these pipelines, we have removed the "aether-qa.pem" file that was baked into the old images. This will now be accessed from the Jenkins system instead.

Because the PEM path is expected to be the same during various steps of the pipeline, using "withCredentials" in each step doesn't work, due to the temp name changing with each invocation. Instead, we will copy it to a location contained in an env var, as reference that env var rather than having a hardcoded path.