### PR TITLE
Update all pipelines for latest builders

### DIFF
--- a/gnbsim.groovy
+++ b/gnbsim.groovy
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// gnbsim.groovy
 
 pipeline {
   options {
@@ -9,16 +10,21 @@ pipeline {
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+    VENV_PATH = "/home/ubuntu/ubuntu_venv"
+  }
+
   stages{
-      
+
     stage('Verify AWS Accessible') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
               credentialsId: 'AKIA6OOX34YQ5DJLY5GJ',
               secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
             sh """
-              aws --region us-west-2 ec2 start-instances --instance-ids    i-000f1f7e33fe5a86e
+              aws --region us-west-2 ec2 start-instances --instance-ids i-000f1f7e33fe5a86e
               aws --region us-west-2 ec2 modify-instance-attribute --no-source-dest-check \
                   --instance-id i-000f1f7e33fe5a86e
               aws --region us-west-2 ec2 describe-instances --instance-ids i-000f1f7e33fe5a86e
@@ -29,20 +35,25 @@ pipeline {
           }
         }
     }
-    
+
     stage('Configure OnRamp') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            sh """
+              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+              sshUserPrivateKey(credentialsId: 'aether-qa', keyFileVariable: 'aether_qa')]) {
+            sh '''
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               NEWIP=\$(aws --region us-west-2 ec2 describe-instances \
                            --instance-ids i-000f1f7e33fe5a86e \
                            --query 'Reservations[0].Instances[0].PrivateIpAddress')
               echo \$NEWIP
               WORKERIP=\$(echo \$NEWIP | tr -d '"')
               echo \$WORKERIP
+              cp -p "$aether_qa" "$PEM_PATH"
               cd $WORKSPACE
-              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
+              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
               cd aether-onramp
               # Determine Local IP
               MYIP=\$(hostname -I | awk '{print \$1}')
@@ -65,8 +76,8 @@ pipeline {
               # Create appropriate hosts.ini file
               cat > hosts.ini << EOF
 [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
-node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
+node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -85,7 +96,7 @@ EOF
               grep -rl "ens18" . | xargs sed -i "s/ens18/\$MYIFC/g"
               sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
               make aether-pingall
-            """ 
+            '''
           }
         }
     }
@@ -93,90 +104,102 @@ EOF
     stage('Install Aether') {
         steps {
           sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
             cd $WORKSPACE/aether-onramp
             make aether-k8s-install
             make aether-5gc-install
             make aether-gnbsim-install
             kubectl get pods -n aether-5gc
-          """ 
+          """
         }
     }
-    
+
     stage("Run gNBsim"){
         steps {
-            sh """
-              cd $WORKSPACE/aether-onramp
-              NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
-              sleep 60
-              make aether-gnbsim-run
-              cd /home/ubuntu
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                 "docker exec  gnbsim-1 cat summary.log"
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                 "docker exec  gnbsim-2 cat summary.log"
-            """
+          sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
+            cd $WORKSPACE/aether-onramp
+            NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
+            sleep 60
+            make aether-gnbsim-run
+            cd /home/ubuntu
+            ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+               "docker exec  gnbsim-1 cat summary.log"
+            ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+               "docker exec  gnbsim-2 cat summary.log"
+          """
         }
     }
-    
+
     stage("Validate Results"){
         steps {
           catchError(message:'Gnbsim Validation is failed', buildResult:'FAILURE',
-            stageResult:'FAILURE') {
-              sh """
-                cd $WORKSPACE/aether-onramp
-                NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
-                cd /home/ubuntu
-                # weaker validation test
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                    "docker exec gnbsim-1 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                    "docker exec gnbsim-2 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
-              """
-          }
-        }
-    }
-    
-    stage("Retrieve Logs") {
-        steps {
+          stageResult:'FAILURE') {
             sh """
-              mkdir $WORKSPACE/logs
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               cd $WORKSPACE/aether-onramp
               NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
               cd /home/ubuntu
-              LOGFILE=\$(ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker exec  gnbsim-1 ls " | grep "gnbsim1-.*.log")  || true
-              echo \$LOGFILE
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker cp gnbsim-1:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
-              scp -i "aether-qa.pem" -o StrictHostKeyChecking=no \
-                     ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
-              LOGFILE=\$(ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker exec  gnbsim-2 ls " | grep "gnbsim2-.*.log")  || true
-              echo \$LOGFILE
-              ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
-                     "docker cp gnbsim-2:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
-              scp -i "aether-qa.pem" -o StrictHostKeyChecking=no \
-                     ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
-              cd $WORKSPACE/logs
-              AMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep amf | awk 'NR==1{print \$1}')
-              echo \$AMF_POD_NAME
-              kubectl logs \$AMF_POD_NAME -n aether-5gc > gnbsim_amf.log
-              WEBUI_POD_NAME=\$(kubectl get pods -n aether-5gc | grep webui | awk 'NR==1{print \$1}')
-              echo \$WEBUI_POD_NAME
-              kubectl logs \$WEBUI_POD_NAME -n aether-5gc > gnbsim_webui.log
-              UDR_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udr | awk 'NR==1{print \$1}')
-              echo \$UDR_POD_NAME
-              kubectl logs \$UDR_POD_NAME -n aether-5gc > gnbsim_udr.log
-              UDM_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udm | awk 'NR==1{print \$1}')
-              echo \$UDM_POD_NAME
-              kubectl logs \$UDM_POD_NAME -n aether-5gc > gnbsim_udm.log
-              AUSF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep ausf | awk 'NR==1{print \$1}')
-              echo \$AUSF_POD_NAME
-              kubectl logs \$AUSF_POD_NAME -n aether-5gc > gnbsim_ausf.log
-              SMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep smf | awk 'NR==1{print \$1}')
-              echo \$SMF_POD_NAME
-              kubectl logs \$SMF_POD_NAME -n aether-5gc > gnbsim_smf.log
+              # weaker validation test
+              ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                  "docker exec gnbsim-1 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
+              ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                  "docker exec gnbsim-2 cat summary.log" | grep "Ue's Passed" | grep -v "Passed: 0"
             """
+          }
+        }
+    }
+
+    stage("Retrieve Logs") {
+        steps {
+          sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
+            mkdir $WORKSPACE/logs
+            cd $WORKSPACE/aether-onramp
+            NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
+            cd /home/ubuntu
+            LOGFILE=\$(ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker exec  gnbsim-1 ls " | grep "gnbsim1-.*.log")  || true
+            echo \$LOGFILE
+            ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker cp gnbsim-1:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
+            scp -i "$PEM_PATH" -o StrictHostKeyChecking=no \
+                   ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
+            LOGFILE=\$(ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker exec  gnbsim-2 ls " | grep "gnbsim2-.*.log")  || true
+            echo \$LOGFILE
+            ssh -i "$PEM_PATH" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                   "docker cp gnbsim-2:/gnbsim/\$LOGFILE  /home/ubuntu/\$LOGFILE"
+            scp -i "$PEM_PATH" -o StrictHostKeyChecking=no \
+                   ubuntu@\$NODE2_IP:\$LOGFILE $WORKSPACE/logs
+            cd $WORKSPACE/logs
+            AMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep amf | awk 'NR==1{print \$1}')
+            echo \$AMF_POD_NAME
+            kubectl logs \$AMF_POD_NAME -n aether-5gc > gnbsim_amf.log
+            WEBUI_POD_NAME=\$(kubectl get pods -n aether-5gc | grep webui | awk 'NR==1{print \$1}')
+            echo \$WEBUI_POD_NAME
+            kubectl logs \$WEBUI_POD_NAME -n aether-5gc > gnbsim_webui.log
+            UDR_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udr | awk 'NR==1{print \$1}')
+            echo \$UDR_POD_NAME
+            kubectl logs \$UDR_POD_NAME -n aether-5gc > gnbsim_udr.log
+            UDM_POD_NAME=\$(kubectl get pods -n aether-5gc | grep udm | awk 'NR==1{print \$1}')
+            echo \$UDM_POD_NAME
+            kubectl logs \$UDM_POD_NAME -n aether-5gc > gnbsim_udm.log
+            AUSF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep ausf | awk 'NR==1{print \$1}')
+            echo \$AUSF_POD_NAME
+            kubectl logs \$AUSF_POD_NAME -n aether-5gc > gnbsim_ausf.log
+            SMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep smf | awk 'NR==1{print \$1}')
+            echo \$SMF_POD_NAME
+            kubectl logs \$SMF_POD_NAME -n aether-5gc > gnbsim_smf.log
+          """
         }
     }
 
@@ -193,19 +216,21 @@ EOF
       withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
         credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
         sh """
+          if [[ -f $VENV_PATH/bin/activate ]]; then
+            source $VENV_PATH/bin/activate
+          fi
           cd $WORKSPACE/aether-onramp
           make gnbsim-uninstall
           make 5gc-uninstall
           make k8s-uninstall
-          aws --region us-west-2 ec2 stop-instances --instance-ids    i-000f1f7e33fe5a86e
+          aws --region us-west-2 ec2 stop-instances --instance-ids i-000f1f7e33fe5a86e
         """
       }
     }
-    
+
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
     }
   }
 }

--- a/quickstart.groovy
+++ b/quickstart.groovy
@@ -1,30 +1,41 @@
 // SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// quickstart.groovy
 
 pipeline {
   options {
-    timeout(time: 1, unit: 'HOURS') 
+    timeout(time: 1, unit: 'HOURS')
   }
 
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+    VENV_PATH = "/home/ubuntu/ubuntu_venv"
+  }
+
   stages{
 
     stage('Configure OnRamp') {
         steps {
-          sh """
-            cd $WORKSPACE
-            git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-            cd aether-onramp
-            MYIP=\$(hostname -I | awk '{print \$1}')
-            echo "MY IP is: " \$MYIP
-            MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-            echo "MY IFC is: " \$MYIFC
-            cat > hosts.ini << EOF
-            [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+              sh '''
+                if [[ -f $VENV_PATH/bin/activate ]]; then
+                  source $VENV_PATH/bin/activate
+                fi
+                cp -p "$aether_qa" "$PEM_PATH"
+                git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+                cd aether-onramp
+                MYIP=\$(hostname -I | awk '{print \$1}')
+                echo "MY IP is: " \$MYIP
+                MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+                echo "MY IFC is: " \$MYIFC
+                cat > hosts.ini << EOF
+                [all]
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -35,24 +46,28 @@ node1
 [gnbsim_nodes]
 node1
 EOF
-            sudo cp vars/main-quickstart.yml vars/main.yml
-            sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
-            sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
-            make aether-pingall
-          """ 
+                sudo cp vars/main-quickstart.yml vars/main.yml
+                sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
+                sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
+                make aether-pingall
+              '''
+            }
         }
     }
-    
+
     stage('Install Aether') {
         steps {
           sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
             cd $WORKSPACE/aether-onramp
             make aether-k8s-install
             make aether-5gc-install
             make aether-gnbsim-install
             kubectl get pods -n aether-5gc
             docker ps
-          """ 
+          """
         }
     }
 
@@ -60,12 +75,15 @@ EOF
         steps {
             retry(2) {
                  sh """
+                   if [[ -f $VENV_PATH/bin/activate ]]; then
+                     source $VENV_PATH/bin/activate
+                   fi
                    cd $WORKSPACE/aether-onramp
                    sleep 60
                    make aether-gnbsim-run
                    docker exec gnbsim-1 cat summary.log
                  """
-            } 
+            }
         }
     }
 
@@ -77,13 +95,16 @@ EOF
                   # weaker validation test
                   docker exec gnbsim-1 cat summary.log | grep "Ue's Passed" | grep -v "Passed: 0"
                 """
-            }    
+            }
         }
     }
-	
+
     stage ('Retrieve Logs'){
         steps {
             sh '''
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               mkdir $WORKSPACE/logs
               cd $WORKSPACE/logs
               logfile=\$(docker exec gnbsim-1 ls | grep "gnbsim1-.*.log")
@@ -122,6 +143,9 @@ EOF
   post {
     always {
       sh """
+        if [[ -f $VENV_PATH/bin/activate ]]; then
+          source $VENV_PATH/bin/activate
+        fi
         cd $WORKSPACE/aether-onramp
         make gnbsim-uninstall
         make 5gc-uninstall
@@ -132,7 +156,6 @@ EOF
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
     }
   }
 }

--- a/quickstart_amp.groovy
+++ b/quickstart_amp.groovy
@@ -1,30 +1,41 @@
 // SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// quickstart_amp.groovy
 
 pipeline {
   options {
-    timeout(time: 1, unit: 'HOURS') 
+    timeout(time: 1, unit: 'HOURS')
   }
 
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+    VENV_PATH = "/home/ubuntu/ubuntu_venv"
+  }
+
   stages{
 
     stage('Configure OnRamp') {
         steps {
-          sh """
-            cd $WORKSPACE
-            git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-            cd aether-onramp
-            MYIP=\$(hostname -I | awk '{print \$1}')
-            echo "MY IP is: " \$MYIP
-            MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-            echo "MY IFC is: " \$MYIFC
-            cat > hosts.ini << EOF
-            [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+              sh '''
+                if [[ -f $VENV_PATH/bin/activate ]]; then
+                  source $VENV_PATH/bin/activate
+                fi
+                cp -p "$aether_qa" "$PEM_PATH"
+                git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+                cd aether-onramp
+                MYIP=\$(hostname -I | awk '{print \$1}')
+                echo "MY IP is: " \$MYIP
+                MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+                echo "MY IFC is: " \$MYIFC
+                cat > hosts.ini << EOF
+                [all]
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -35,18 +46,22 @@ node1
 [gnbsim_nodes]
 node1
 EOF
-            sudo cp vars/main-quickstart.yml vars/main.yml
-            sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
-            sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
-            sudo sed -i "s/standalone: true/standalone: false/" vars/main.yml
-            make aether-pingall
-          """ 
+                sudo cp vars/main-quickstart.yml vars/main.yml
+                sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
+                sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
+                sudo sed -i "s/standalone: true/standalone: false/" vars/main.yml
+                make aether-pingall
+              '''
+            }
         }
     }
-    
+
     stage('Install Aether') {
         steps {
           sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
             cd $WORKSPACE/aether-onramp
             make aether-k8s-install
             make aether-amp-install
@@ -54,7 +69,7 @@ EOF
             make aether-gnbsim-install
             kubectl get pods -n aether-5gc
             docker ps
-          """ 
+          """
         }
     }
 
@@ -62,12 +77,15 @@ EOF
         steps {
             retry(2) {
                  sh """
+                   if [[ -f $VENV_PATH/bin/activate ]]; then
+                     source $VENV_PATH/bin/activate
+                   fi
                    cd $WORKSPACE/aether-onramp
                    sleep 60
                    make aether-gnbsim-run
                    docker exec gnbsim-1 cat summary.log
                  """
-            } 
+            }
         }
     }
 
@@ -79,13 +97,16 @@ EOF
                   # weaker validation test
                   docker exec gnbsim-1 cat summary.log | grep "Ue's Passed" | grep -v "Passed: 0"
                 """
-            }    
+            }
         }
     }
-	
+
     stage ('Retrieve Logs'){
         steps {
             sh '''
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               mkdir $WORKSPACE/logs
               cd $WORKSPACE/logs
               logfile=\$(docker exec gnbsim-1 ls | grep "gnbsim1-.*.log")
@@ -124,6 +145,9 @@ EOF
   post {
     always {
       sh """
+        if [[ -f $VENV_PATH/bin/activate ]]; then
+          source $VENV_PATH/bin/activate
+        fi
         cd $WORKSPACE/aether-onramp
         make gnbsim-uninstall
         make 5gc-uninstall
@@ -135,7 +159,6 @@ EOF
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
     }
   }
 }

--- a/sdran.groovy
+++ b/sdran.groovy
@@ -1,30 +1,41 @@
 // SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// sdran.groovy
 
 pipeline {
   options {
-    timeout(time: 1, unit: 'HOURS') 
+    timeout(time: 1, unit: 'HOURS')
   }
 
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+    VENV_PATH = "/home/ubuntu/ubuntu_venv"
+  }
+
   stages{
 
     stage('Configure OnRamp') {
         steps {
-          sh """
-            cd $WORKSPACE
-            git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
-            cd aether-onramp
-            MYIP=\$(hostname -I | awk '{print \$1}')
-            echo "MY IP is: " \$MYIP
-            MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
-            echo "MY IFC is: " \$MYIFC
-            cat > hosts.ini << EOF
-            [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+            withCredentials([sshUserPrivateKey(credentialsId: 'aether-qa',
+            keyFileVariable: 'aether_qa', usernameVariable: 'aether_qa_user')]) {
+              sh '''
+                if [[ -f $VENV_PATH/bin/activate ]]; then
+                  source $VENV_PATH/bin/activate
+                fi
+                cp -p "$aether_qa" "$PEM_PATH"
+                git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
+                cd aether-onramp
+                MYIP=\$(hostname -I | awk '{print \$1}')
+                echo "MY IP is: " \$MYIP
+                MYIFC=\$(ip route get 8.8.8.8| awk '{print \$5}'|awk /./)
+                echo "MY IFC is: " \$MYIFC
+                cat > hosts.ini << EOF
+                [all]
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -35,24 +46,28 @@ node1
 [gnbsim_nodes]
 node1
 EOF
-            sudo cp vars/main-sdran.yml vars/main.yml
-            sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
-            sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
-            make aether-pingall
-          """ 
+                sudo cp vars/main-sdran.yml vars/main.yml
+                sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
+                sudo sed -i "s/ens18/\$MYIFC/g" vars/main.yml
+                make aether-pingall
+              '''
+            }
         }
     }
-    
+
     stage('Install Aether') {
         steps {
           sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
             cd $WORKSPACE/aether-onramp
             make k8s-install
             make 5gc-install
             make sdran-install
             kubectl get pods -n aether-5gc
             kubectl get pods -n sdran
-          """ 
+          """
         }
     }
 
@@ -61,6 +76,9 @@ EOF
             catchError(message:'RANSIM Validation fails', buildResult:'FAILURE', stageResult:'FAILURE')
             {
               sh """
+                if [[ -f $VENV_PATH/bin/activate ]]; then
+                  source $VENV_PATH/bin/activate
+                fi
                 cd $WORKSPACE
                 echo "Give the simulator a chance to run (ideally, playbook should loop until done)"
                 sleep 60
@@ -70,13 +88,16 @@ EOF
                 kubectl exec -i deployment/onos-cli -n sdran -- onos topo get entity e2cell >> ransim.log
                 cat ransim.log
               """
-            }    
+            }
         }
     }
-	
+
     stage ('Retrieve Logs'){
         steps {
             sh '''
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               cd $WORKSPACE
               mkdir logs
               cp ransim.log logs
@@ -114,6 +135,9 @@ EOF
   post {
     always {
       sh """
+        if [[ -f $VENV_PATH/bin/activate ]]; then
+          source $VENV_PATH/bin/activate
+        fi
         cd $WORKSPACE/aether-onramp
         make sdran-uninstall
         make 5gc-uninstall
@@ -124,7 +148,6 @@ EOF
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
     }
   }
 }

--- a/ueransim.groovy
+++ b/ueransim.groovy
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Open Networking Foundation <info@opennetworking.org>
 // SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+// ueransim.groovy
 
 pipeline {
   options {
@@ -9,9 +10,14 @@ pipeline {
   agent {
         label "${AgentLabel}"
   }
-    
+
+  environment {
+    PEM_PATH = "/home/ubuntu/aether-qa.pem"
+    VENV_PATH = "/home/ubuntu/ubuntu_venv"
+  }
+
   stages{
-      
+
     stage('Verify AWS Accessible') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
@@ -29,20 +35,25 @@ pipeline {
           }
         }
     }
-    
+
     stage('Configure OnRamp') {
         steps {
           withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            sh """
+              credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+              sshUserPrivateKey(credentialsId: 'aether-qa', keyFileVariable: 'aether_qa')]) {
+            sh '''
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               NEWIP=\$(aws --region us-west-2 ec2 describe-instances \
                            --instance-ids i-000f1f7e33fe5a86e \
                            --query 'Reservations[0].Instances[0].PrivateIpAddress')
               echo \$NEWIP
               WORKERIP=\$(echo \$NEWIP | tr -d '"')
               echo \$WORKERIP
+              cp -p "$aether_qa" "$PEM_PATH"
               cd $WORKSPACE
-              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git 
+              git clone --recursive https://github.com/opennetworkinglab/aether-onramp.git
               cd aether-onramp
               # Determine Local IP
               MYIP=\$(hostname -I | awk '{print \$1}')
@@ -65,8 +76,8 @@ pipeline {
               # Create appropriate hosts.ini file
               cat > hosts.ini << EOF
 [all]
-node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
-node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/aether-qa.pem ansible_sudo_pass=ubuntu
+node1 ansible_host=\$MYIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
+node2 ansible_host=\$WORKERIP ansible_user=ubuntu ansible_ssh_private_key_file=$PEM_PATH ansible_sudo_pass=ubuntu
 
 [master_nodes]
 node1
@@ -86,7 +97,7 @@ EOF
               sudo sed -i "s/10.76.28.113/\$MYIP/" vars/main.yml
               sudo sed -i "s/10.76.28.111/\$NODE2_IP/" vars/main.yml
               make aether-pingall
-            """ 
+            '''
           }
         }
     }
@@ -94,18 +105,24 @@ EOF
     stage('Install Aether') {
         steps {
           sh """
+            if [[ -f $VENV_PATH/bin/activate ]]; then
+              source $VENV_PATH/bin/activate
+            fi
             cd $WORKSPACE/aether-onramp
             make aether-k8s-install
             make aether-5gc-install
             make aether-ueransim-install
             kubectl get pods -n aether-5gc
-          """ 
+          """
         }
     }
-    
+
     stage("Run UERANSIM"){
         steps {
             sh """
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               cd $WORKSPACE/aether-onramp
               sleep 60
               make aether-ueransim-run
@@ -113,28 +130,34 @@ EOF
             """
         }
     }
-            
+
     stage("Validate Results"){
         steps {
           catchError(message:'UERANSIM Validation has failed', buildResult:'FAILURE',
             stageResult:'FAILURE') {
               sh """
+                if [[ -f $VENV_PATH/bin/activate ]]; then
+                  source $VENV_PATH/bin/activate
+                fi
                 cd $WORKSPACE/aether-onramp
                 NODE2_IP=\$(grep ansible_host hosts.ini | grep node2 | awk -F" |=" '{print \$3}')
                 # substitute some observable action, such as iperf
                 cd /home/ubuntu
-                ssh -i "aether-qa.pem" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
+                ssh -i "${env.PEM_PATH}" -o StrictHostKeyChecking=no ubuntu@\$NODE2_IP \
 		   "ip a | grep -A 1 'uesimtun0' | grep inet | awk '{print \$2}' | cut -d'/' -f1"
               """
           }
         }
     }
-    
+
     stage("Retrieve Logs"){
         steps {
             sh '''
+              if [[ -f $VENV_PATH/bin/activate ]]; then
+                source $VENV_PATH/bin/activate
+              fi
               mkdir $WORKSPACE/logs
-              cd $WORKSPACE/logs 
+              cd $WORKSPACE/logs
               AMF_POD_NAME=\$(kubectl get pods -n aether-5gc | grep amf | awk 'NR==1{print \$1}')
               echo "${AMF_POD_NAME}"
               kubectl logs $AMF_POD_NAME -n aether-5gc > ueransim_amf.log
@@ -170,6 +193,9 @@ EOF
       withCredentials([aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID',
         credentialsId: 'AKIA6OOX34YQ5DJLY5GJ', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
         sh """
+          if [[ -f $VENV_PATH/bin/activate ]]; then
+            source $VENV_PATH/bin/activate
+          fi
           cd $WORKSPACE/aether-onramp
           make ueransim-uninstall
           make 5gc-uninstall
@@ -178,11 +204,10 @@ EOF
         """
       }
     }
-    
+
     // triggered when red sign
     failure {
         slackSend color: "danger", message: "FAILED ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BUILD_URL}"
-            
     }
   }
 }


### PR DESCRIPTION
A requirement for Ubuntu 24.04 and later versions to come is to have
all Python packages installed into a venv, rather than globally. In
order to keep the pipelines compatible with both older and newer
build images, the path to the venv is checked before each shell step
(except those utilizing only the aws-cli), and if the venv is present
on the agent, it is activated.

To improve security, the key used to make connections between agents
is no longer included on the image, but is put in place at
run-time from the Jenkins server.

Finally, there are some small changes, including adding the file name
to the top of each file (helpful when troubleshooting or replaying
pipelines) and cleaning up whitespace.